### PR TITLE
参数化水印嵌入强度。

### DIFF
--- a/成员代码/LinXianghong/PR_TEMPLATE.md
+++ b/成员代码/LinXianghong/PR_TEMPLATE.md
@@ -1,0 +1,52 @@
+# 水印嵌入代码改进
+
+## 改进内容
+- [x] 添加错误处理机制
+  - 添加文件存在性检查
+  - 添加异常处理
+  - 确保输出目录存在
+- [ ] 参数化水印嵌入强度（待实现）
+
+## 具体改动
+1. 在`convert_image`函数中：
+   - 添加了文件存在性检查
+   - 添加了异常处理机制
+   - 使用`os.makedirs`确保输出目录存在
+
+2. 在`embed_watermark_to_image`函数中：
+   - 添加了完整的异常处理
+   - 优化了代码结构
+   - 确保输出目录存在
+
+## 测试结果
+- [x] 测试文件不存在的情况
+- [x] 测试输出目录不存在的情况
+- [x] 测试正常水印嵌入流程
+
+## 使用示例
+```python
+# 正常使用
+embed_watermark_to_image("original.jpg", "watermark.jpg", "result.jpg")
+
+# 错误处理示例
+try:
+    embed_watermark_to_image("not_exist.jpg", "watermark.jpg", "result.jpg")
+except Exception as e:
+    print(f"错误信息: {str(e)}")
+```
+
+## 错误信息示例
+- 文件不存在：`找不到图像文件: ./pictures/original.jpg`
+- 图像处理错误：`图像处理过程中出错: [具体错误信息]`
+- 水印嵌入错误：`水印嵌入过程中出错: [具体错误信息]`
+
+## 后续计划
+- [ ] 实现水印嵌入强度参数化
+- [ ] 添加水印提取功能
+- [ ] 添加水印鲁棒性测试
+
+## 相关文件
+- `watermarkHide.py`: 主要代码文件
+- `pictures/`: 输入图像目录
+- `dataset/`: 处理后的图像目录
+- `result/`: 输出结果目录 

--- a/成员代码/LinXianghong/watermarkHide.py
+++ b/成员代码/LinXianghong/watermarkHide.py
@@ -6,7 +6,7 @@ import pywt
 from scipy.fftpack import dct, idct
  
 # 转换图像为numpy数组
-# is_watermark为True时转为灰度图，False时保持RGB格式
+# is_watermark为True时转为灰度图，False时保持   RGB格式      
 def convert_image(image_name, size, is_watermark=False):
     img_path = os.path.join('./pictures', image_name)
     img = Image.open(img_path).resize((size, size), Image.Resampling.LANCZOS)

--- a/成员代码/LinXianghong/watermarkHide.py
+++ b/成员代码/LinXianghong/watermarkHide.py
@@ -84,7 +84,14 @@ def embed_watermark(watermark_array, dwt_coeffs, alpha=80):
     return dwt_coeffs_watermarked
 
 # 主函数：完成水印嵌入的整个流程
-def embed_watermark_to_image(image_name, watermark_name, output_name):
+def embed_watermark_to_image(image_name, watermark_name, output_name, alpha=80):
+    """
+    将水印嵌入到图像中
+    :param image_name: 原始图像文件名
+    :param watermark_name: 水印图像文件名
+    :param output_name: 输出图像文件名
+    :param alpha: 水印嵌入强度，默认值为80
+    """
     try:
         # 读取原始图像(RGB)和水印图像(灰度)
         image_array = convert_image(image_name, 4096, False)
@@ -95,7 +102,7 @@ def embed_watermark_to_image(image_name, watermark_name, output_name):
         b_channel = image_array[:,:,2]
         
         dwt_coeffs = process_dwt(r_channel)
-        dwt_coeffs_watermarked = embed_watermark(watermark_array, dwt_coeffs)
+        dwt_coeffs_watermarked = embed_watermark(watermark_array, dwt_coeffs, alpha)
         
         r_channel_watermarked = pywt.waverec2(dwt_coeffs_watermarked, 'haar')
         r_channel_watermarked = np.clip(r_channel_watermarked, 0, 255)

--- a/成员代码/LinXianghong/watermarkHide.py
+++ b/成员代码/LinXianghong/watermarkHide.py
@@ -8,18 +8,26 @@ from scipy.fftpack import dct, idct
 # 转换图像为numpy数组
 # is_watermark为True时转为灰度图，False时保持   RGB格式      
 def convert_image(image_name, size, is_watermark=False):
-    img_path = os.path.join('./pictures', image_name)
-    img = Image.open(img_path).resize((size, size), Image.Resampling.LANCZOS)
-    if is_watermark:
-        # 水印图像转为灰度
-        img = img.convert('L')
-        image_array = np.array(img, dtype=np.float64)
-    else:
-        # 载体图像保持RGB
-        image_array = np.array(img, dtype=np.float64)
-    img_path_save = os.path.join('./dataset', image_name)
-    img.save(img_path_save)
-    return image_array
+    try:
+        img_path = os.path.join('./pictures', image_name)
+        if not os.path.exists(img_path):
+            raise FileNotFoundError(f"找不到图像文件: {img_path}")
+            
+        img = Image.open(img_path).resize((size, size), Image.Resampling.LANCZOS)
+        if is_watermark:
+            # 水印图像转为灰度
+            img = img.convert('L')
+            image_array = np.array(img, dtype=np.float64)
+        else:
+            # 载体图像保持RGB
+            image_array = np.array(img, dtype=np.float64)
+            
+        img_path_save = os.path.join('./dataset', image_name)
+        os.makedirs(os.path.dirname(img_path_save), exist_ok=True)
+        img.save(img_path_save)
+        return image_array
+    except Exception as e:
+        raise Exception(f"图像处理过程中出错: {str(e)}")
 
 # 对图像进行小波变换
 def process_dwt(image_array, level=1):
@@ -48,64 +56,69 @@ def inverse_dct(all_subdct):
     return all_subidct
 
 # 在DWT低频系数中嵌入水印
-def embed_watermark(watermark_array, dwt_coeffs):
-    # 获取低频系数
+def embed_watermark(watermark_array, dwt_coeffs, alpha=80):
+    """
+    在DWT低频系数中嵌入水印
+    :param watermark_array: 水印图像数组
+    :param dwt_coeffs: DWT系数
+    :param alpha: 水印嵌入强度，默认值为80
+    :return: 嵌入水印后的DWT系数
+    """
     LL = dwt_coeffs[0]
-    # 对低频系数进行DCT变换
     dct_coeffs = apply_dct(LL)
-    # 将水印展平并二值化
     watermark_flat = (watermark_array.ravel() > 128).astype(np.float64)
     ind = 0
-    # 在DCT系数中嵌入水印
+    
     for x in range(0, dct_coeffs.shape[0], 8):
         for y in range(0, dct_coeffs.shape[1], 8):
             if ind < watermark_flat.size:
-                if(watermark_flat[ind] == 1) :
-                    dct_coeffs[x+1, y+1] = dct_coeffs[x+2, y+2] + 80
-                elif(watermark_flat[ind] == 0) :
-                    dct_coeffs[x+1, y+1] = dct_coeffs[x+2, y+2] - 80
+                if(watermark_flat[ind] == 1):
+                    dct_coeffs[x+1, y+1] = dct_coeffs[x+2, y+2] + alpha
+                elif(watermark_flat[ind] == 0):
+                    dct_coeffs[x+1, y+1] = dct_coeffs[x+2, y+2] - alpha
                 ind += 1
-    # DCT逆变换
+    
     LL_watermarked = inverse_dct(dct_coeffs)
-
-    # 更新DWT系数
     dwt_coeffs_watermarked = list(dwt_coeffs)
     dwt_coeffs_watermarked[0] = LL_watermarked
     return dwt_coeffs_watermarked
 
 # 主函数：完成水印嵌入的整个流程
 def embed_watermark_to_image(image_name, watermark_name, output_name):
-    # 读取原始图像(RGB)和水印图像(灰度)
-    image_array = convert_image(image_name, 4096, False)
-    watermark_array = convert_image(watermark_name, 256, True)
-    # 分离RGB通道
-    r_channel = image_array[:,:,0]
-    g_channel = image_array[:,:,1]
-    b_channel = image_array[:,:,2]
-    # 对R通道进行DWT变换
-    dwt_coeffs = process_dwt(r_channel)
-    # 嵌入水印
-    dwt_coeffs_watermarked = embed_watermark(watermark_array, dwt_coeffs)
-    # 小波逆变换得到嵌入水印后的R通道
-    r_channel_watermarked = pywt.waverec2(dwt_coeffs_watermarked, 'haar')
-    # 处理像素值范围
-    r_channel_watermarked = np.clip(r_channel_watermarked, 0, 255)
-    # 重新组合RGB通道
-    watermarked_image = np.dstack((r_channel_watermarked, g_channel, b_channel)).astype(np.uint8)
-    # 保存结果
-    img = Image.fromarray(watermarked_image)
-    img.save(os.path.join('./result', output_name))
-    # 解决中文显示问题
-    plt.rcParams['font.sans-serif'] = ['SimHei']
-    plt.rcParams['axes.unicode_minus'] = False
-    # 显示结果
-    plt.figure(figsize=(10, 5))
-    plt.subplot(1, 2, 1)
-    plt.imshow(image_array.astype(np.uint8))
-    plt.title('原始图像')
-    plt.axis('off')
-    plt.subplot(1, 2, 2)
-    plt.imshow(watermarked_image)
-    plt.title('嵌入图像')
-    plt.axis('off')
-    plt.show()
+    try:
+        # 读取原始图像(RGB)和水印图像(灰度)
+        image_array = convert_image(image_name, 4096, False)
+        watermark_array = convert_image(watermark_name, 256, True)
+        
+        r_channel = image_array[:,:,0]
+        g_channel = image_array[:,:,1]
+        b_channel = image_array[:,:,2]
+        
+        dwt_coeffs = process_dwt(r_channel)
+        dwt_coeffs_watermarked = embed_watermark(watermark_array, dwt_coeffs)
+        
+        r_channel_watermarked = pywt.waverec2(dwt_coeffs_watermarked, 'haar')
+        r_channel_watermarked = np.clip(r_channel_watermarked, 0, 255)
+        
+        watermarked_image = np.dstack((r_channel_watermarked, g_channel, b_channel)).astype(np.uint8)
+        
+        output_path = os.path.join('./result', output_name)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        img = Image.fromarray(watermarked_image)
+        img.save(output_path)
+        
+        plt.rcParams['font.sans-serif'] = ['SimHei']
+        plt.rcParams['axes.unicode_minus'] = False
+        
+        plt.figure(figsize=(10, 5))
+        plt.subplot(1, 2, 1)
+        plt.imshow(image_array.astype(np.uint8))
+        plt.title('原始图像')
+        plt.axis('off')
+        plt.subplot(1, 2, 2)
+        plt.imshow(watermarked_image)
+        plt.title('嵌入图像')
+        plt.axis('off')
+        plt.show()
+    except Exception as e:
+        raise Exception(f"水印嵌入过程中出错: {str(e)}")

--- a/成员代码/LinXianghong/watermarkHide.py
+++ b/成员代码/LinXianghong/watermarkHide.py
@@ -6,7 +6,7 @@ import pywt
 from scipy.fftpack import dct, idct
  
 # 转换图像为numpy数组
-# is_watermark为True时转为灰度图，False时保持   RGB格式      
+# is_watermark为True时转为灰度图，False时保持RGB格式      
 def convert_image(image_name, size, is_watermark=False):
     try:
         img_path = os.path.join('./pictures', image_name)


### PR DESCRIPTION
# 水印嵌入代码改进

## 改进内容
- [x] 添加错误处理机制
  - 添加文件存在性检查
  - 添加异常处理
  - 确保输出目录存在
- [x] 参数化水印嵌入强度
  - 添加alpha参数控制嵌入强度
  - 设置默认值为80
  - 添加函数文档说明

## 具体改动
1. 在`convert_image`函数中：
   - 添加了文件存在性检查
   - 添加了异常处理机制
   - 使用`os.makedirs`确保输出目录存在

2. 在`embed_watermark`函数中：
   - 添加了`alpha`参数，默认值为80
   - 使用`alpha`参数替代固定嵌入强度值
   - 添加了函数文档字符串

3. 在`embed_watermark_to_image`函数中：
   - 添加了`alpha`参数，默认值为80
   - 将`alpha`参数传递给`embed_watermark`函数
   - 添加了完整的函数文档字符串

## 测试结果
- [x] 测试文件不存在的情况
- [x] 测试输出目录不存在的情况
- [x] 测试正常水印嵌入流程
- [x] 测试不同alpha值的水印嵌入效果
  - alpha=50（弱水印）
  - alpha=80（默认值）
  - alpha=120（强水印）

## 使用示例
```python
# 使用默认嵌入强度
embed_watermark_to_image("original.jpg", "watermark.jpg", "result.jpg")

# 使用自定义嵌入强度
embed_watermark_to_image("original.jpg", "watermark.jpg", "result.jpg", alpha=100)  # 更强的水印
embed_watermark_to_image("original.jpg", "watermark.jpg", "result.jpg", alpha=50)   # 更弱的水印
```

## 错误信息示例
- 文件不存在：`找不到图像文件: ./pictures/original.jpg`
- 图像处理错误：`图像处理过程中出错: [具体错误信息]`
- 水印嵌入错误：`水印嵌入过程中出错: [具体错误信息]`

## 参数说明
- `alpha`：水印嵌入强度参数
  - 默认值：80
  - 建议范围：50-120
  - 值越大，水印越明显但可能影响图像质量
  - 值越小，水印越隐蔽但可能影响提取效果

## 后续计划
- [ ] 添加水印提取功能
- [ ] 添加水印鲁棒性测试
- [ ] 添加自适应alpha值选择算法

## 相关文件
- `watermarkHide.py`: 主要代码文件
- `pictures/`: 输入图像目录
- `dataset/`: 处理后的图像目录
- `result/`: 输出结果目录 
